### PR TITLE
Remove 'builds' dir from EmailReport location

### DIFF
--- a/vars/Pipeline.groovy
+++ b/vars/Pipeline.groovy
@@ -240,8 +240,8 @@ def call() {
                             """
                             awsHelper.uploadCharts()
                             //Send email for failed results.
-                            if (fileExists("${PWD}/builds/SummarizedEmailReport.html")) {
-                                def emailBody = readFile "${PWD}/builds/SummarizedEmailReport.html"
+                            if (fileExists("${PWD}/SummarizedEmailReport.html")) {
+                                def emailBody = readFile "${PWD}/SummarizedEmailReport.html"
                                 email.send("'${env.JOB_NAME}' Integration Test Results! #(${env.BUILD_NUMBER})", "${emailBody}")
                             } else {
                                 echo "No SummarizedEmailReport.html file found!!"


### PR DESCRIPTION
## Purpose
According to the new folder structure of the TestGrid job, `builds` directory will not be created.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes