### PR TITLE
Remove unnecessary build directory from chart generation path

### DIFF
--- a/src/org/wso2/tg/jenkins/util/AWSUtils.groovy
+++ b/src/org/wso2/tg/jenkins/util/AWSUtils.groovy
@@ -28,7 +28,7 @@ def uploadToS3(testPlanId) {
 def uploadCharts() {
     def s3BucketName = getS3BucketName()
     sh """
-      aws s3 sync ${TESTGRID_HOME}/jobs/${PRODUCT}/builds/ s3://${s3BucketName}/charts/${PRODUCT}/ --exclude "*" --include "*.png" --acl public-read
+      aws s3 sync ${TESTGRID_HOME}/jobs/${PRODUCT}/ s3://${s3BucketName}/charts/${PRODUCT}/ --exclude "*" --include "*.png" --acl public-read
       """
 }
 


### PR DESCRIPTION
## Purpose
Remove unnecessary build directory from chart generation path

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes