### PR TITLE
Change the keys used for deployments 

### DIFF
--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -20,17 +20,17 @@ package org.wso2.tg.jenkins
 @Singleton
 class Properties {
 
-    static def TESTGRID_NAME                = "WSO2-TestGrid"
-    static def TESTGRID_HOME                = "/testgrid/testgrid-home"
-    static def TESTGRID_DIST_LOCATION       = TESTGRID_HOME + "/testgrid-dist"
-    static def JOB_CONFIG_YAML              = "job-config.yaml"
-    static def SQL_DRIVERS_LOCATION_UNIX    ="/opt/testgrid/sql-drivers/"
-    static def SQL_DRIVERS_LOCATION_WINDOWS ="/testgrid/sql-drivers"
-    static def REMOTE_WORKSPACE_DIR_UNIX    ="/opt/testgrid/workspace"
-    static def REMOTE_WORKSPACE_DIR_WINDOWS ="c:/testgrid/workspace"
-    static def CONFIG_PROPERTY_FILE_PATH    = TESTGRID_HOME + "/config.properties"
-    static def DEFAULT_EXECUTOR_COUNT       = 12
-    static def SSH_KEY_FILE_PATH            = "workspace/testgrid-key.pem"
+    final static def TESTGRID_NAME                = "WSO2-TestGrid"
+    final static def TESTGRID_HOME                = "/testgrid/testgrid-home"
+    final static def TESTGRID_DIST_LOCATION       = TESTGRID_HOME + "/testgrid-dist"
+    final static def JOB_CONFIG_YAML              = "job-config.yaml"
+    final static def SQL_DRIVERS_LOCATION_UNIX    ="/opt/testgrid/sql-drivers/"
+    final static def SQL_DRIVERS_LOCATION_WINDOWS ="/testgrid/sql-drivers"
+    final static def REMOTE_WORKSPACE_DIR_UNIX    ="/opt/testgrid/workspace"
+    final static def REMOTE_WORKSPACE_DIR_WINDOWS ="c:/testgrid/workspace"
+    final static def CONFIG_PROPERTY_FILE_PATH    = TESTGRID_HOME + "/config.properties"
+    final static def DEFAULT_EXECUTOR_COUNT       = 12
+    final static def SSH_KEY_FILE_PATH            = "workspace/testgrid-key.pem"
 
     // Job Properties which are set when init is called
     static def PRODUCT

--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -30,6 +30,7 @@ class Properties {
     static def REMOTE_WORKSPACE_DIR_WINDOWS ="c:/testgrid/workspace"
     static def CONFIG_PROPERTY_FILE_PATH    = TESTGRID_HOME + "/config.properties"
     static def DEFAULT_EXECUTOR_COUNT       = 12
+    static def SSH_KEY_FILE_PATH            = "workspace/testgrid-key.pem"
 
     // Job Properties which are set when init is called
     static def PRODUCT

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -128,9 +128,14 @@ def prepareWorkspace(testPlanId) {
 
         echo Cloning ${props.INFRASTRUCTURE_REPOSITORY} into ${props.WORKSPACE}/${testPlanId}/${props.INFRA_LOCATION}
         git clone ${props.INFRASTRUCTURE_REPOSITORY}
-        cp /testgrid/testgrid-prod-key.pem ${props.WORKSPACE}/${testPlanId}/workspace/testgrid-key.pem
         chmod 400 ${props.WORKSPACE}/${testPlanId}/workspace/testgrid-key.pem
         echo Workspace directory content:
         ls ${props.WORKSPACE}/${testPlanId}/
     """
+    log.info("Copying the ssh key file to workspace : ${props.WORKSPACE}/${testPlanId}/${props.SSH_KEY_FILE_PATH}")
+    withCredentials([file(credentialsId: 'DEPLOYMENT_KEY', variable: 'keyLocation')]) {
+        sh """
+            cp ${keyLocation} ${props.WORKSPACE}/${testPlanId}/${props.SSH_KEY_FILE_PATH}
+        """
+    }
 }

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -125,10 +125,8 @@ def prepareWorkspace(testPlanId) {
         echo Cloning ${props.SCENARIOS_REPOSITORY} into ${props.WORKSPACE}/${testPlanId}/${props.SCENARIOS_LOCATION}
         cd ${props.WORKSPACE}/${testPlanId}/workspace
         git clone ${props.SCENARIOS_REPOSITORY}
-
         echo Cloning ${props.INFRASTRUCTURE_REPOSITORY} into ${props.WORKSPACE}/${testPlanId}/${props.INFRA_LOCATION}
         git clone ${props.INFRASTRUCTURE_REPOSITORY}
-        chmod 400 ${props.WORKSPACE}/${testPlanId}/workspace/testgrid-key.pem
         echo Workspace directory content:
         ls ${props.WORKSPACE}/${testPlanId}/
     """
@@ -136,6 +134,7 @@ def prepareWorkspace(testPlanId) {
     withCredentials([file(credentialsId: 'DEPLOYMENT_KEY', variable: 'keyLocation')]) {
         sh """
             cp ${keyLocation} ${props.WORKSPACE}/${testPlanId}/${props.SSH_KEY_FILE_PATH}
+            chmod 400 ${props.WORKSPACE}/${testPlanId}/${props.SSH_KEY_FILE_PATH}
         """
     }
 }

--- a/src/org/wso2/tg/jenkins/util/WorkSpaceUtils.groovy
+++ b/src/org/wso2/tg/jenkins/util/WorkSpaceUtils.groovy
@@ -33,7 +33,7 @@ def createJobConfigYamlFile(def filePath) {
     // https://jenkins.io/doc/pipeline/steps/pipeline-utility-steps/#writeyaml-write-a-yaml
     log.info("Creating Job-config.yaml at : {$filePath}")
     sh """
-    echo 'keyFileLocation: workspace/testgrid-key.pem' > ${filePath}
+    echo 'keyFileLocation: {$props.SSH_KEY_FILE_PATH}' > ${filePath}
     echo 'infrastructureRepository: ${props.INFRA_LOCATION}/' >> ${filePath}
     echo 'deploymentRepository: ${props.INFRA_LOCATION}/' >> ${filePath}
     echo 'scenarioTestsRepository: ${props.SCENARIOS_LOCATION}' >> ${filePath}

--- a/src/org/wso2/tg/jenkins/util/WorkSpaceUtils.groovy
+++ b/src/org/wso2/tg/jenkins/util/WorkSpaceUtils.groovy
@@ -33,7 +33,7 @@ def createJobConfigYamlFile(def filePath) {
     // https://jenkins.io/doc/pipeline/steps/pipeline-utility-steps/#writeyaml-write-a-yaml
     log.info("Creating Job-config.yaml at : {$filePath}")
     sh """
-    echo 'keyFileLocation: {$props.SSH_KEY_FILE_PATH}' > ${filePath}
+    echo 'keyFileLocation: ${props.SSH_KEY_FILE_PATH}' > ${filePath}
     echo 'infrastructureRepository: ${props.INFRA_LOCATION}/' >> ${filePath}
     echo 'deploymentRepository: ${props.INFRA_LOCATION}/' >> ${filePath}
     echo 'scenarioTestsRepository: ${props.SCENARIOS_LOCATION}' >> ${filePath}


### PR DESCRIPTION
## Purpose
This PR Changes the keys used for deployments. Now we have two different keys for prod and dev deployments. Which will be retrieved from Jenkins credentials plugin. 

## Goals
> Secure testgrid deployment

## Approach
> Retrieve deployment key from the Credentials plugin
