### PR TITLE
Remove getting redundant inputs of repository locations.

### DIFF
--- a/src/org/wso2/tg/jenkins/Properties.groovy
+++ b/src/org/wso2/tg/jenkins/Properties.groovy
@@ -34,6 +34,9 @@ class Properties {
     final static def DEFAULT_EXECUTOR_COUNT       = 12
     final static def SSH_KEY_FILE_PATH            = "workspace/testgrid-key.pem"
     final static def TESTGRID_JOB_CONFIG_REPOSITORY = "https://github.com/wso2-incubator/testgrid-job-configs.git"
+    final static def INFRA_LOCATION               = "InfraRepository"
+    final static def DEPLOYMENT_LOCATION          = "DeploymentRepository"
+    final static def SCENARIOS_LOCATION           = "ScenariosRepository"
 
     // Job Properties which are set when init is called
     static def PRODUCT
@@ -54,15 +57,12 @@ class Properties {
     static def WUM_PRODUCT_VERSION
     static def USE_CUSTOM_TESTNG
     static def EXECUTOR_COUNT
-    static def INFRA_LOCATION
     static def LATEST_PRODUCT_RELEASE_API
     static def LATEST_PRODUCT_BUILD_ARTIFACTS_API
     static def WORKSPACE
     static def SCENARIOS_REPOSITORY
     static def INFRASTRUCTURE_REPOSITORY
     static def EMAIL_TO_LIST
-    static def SCENARIOS_LOCATION
-    static def DEPLOYMENT_LOCATION
 
 
     /**
@@ -89,14 +89,11 @@ class Properties {
         WUM_UAT_APP_KEY = getCredentials("WUM_UAT_APPKEY", false)
         USER_NAME = getCredentials("WUM_USERNAME", false)
         PASSWORD = getCredentials("WUM_PASSWORD", false)
-        INFRA_LOCATION = getJobProperty("INFRA_LOCATION")
         LATEST_PRODUCT_RELEASE_API = getJobProperty("LATEST_PRODUCT_RELEASE_API", false)
         LATEST_PRODUCT_BUILD_ARTIFACTS_API = getJobProperty("LATEST_PRODUCT_BUILD_ARTIFACTS_API", false)
         SCENARIOS_REPOSITORY = getJobProperty("SCENARIOS_REPOSITORY")
         INFRASTRUCTURE_REPOSITORY = getJobProperty("INFRASTRUCTURE_REPOSITORY")
         EMAIL_TO_LIST = getJobProperty("EMAIL_TO_LIST")
-        SCENARIOS_LOCATION = getJobProperty("SCENARIOS_LOCATION")
-        DEPLOYMENT_LOCATION = getJobProperty("DEPLOYMENT_LOCATION")
     }
 
     /**

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -123,15 +123,16 @@ def prepareWorkspace(testPlanId) {
         mkdir -p ${props.WORKSPACE}/${testPlanId}/workspace
         #Cloning should be done before unstashing TestGridYaml since its going to be injected
         #inside the cloned repository
-        echo Cloning ${props.SCENARIOS_REPOSITORY} into ${props.WORKSPACE}/${testPlanId}/${props.SCENARIOS_LOCATION}
         cd ${props.WORKSPACE}/${testPlanId}/workspace
-        git clone ${props.SCENARIOS_REPOSITORY}
-        if [ ${props.SCENARIOS_REPOSITORY} = ${props.INFRASTRUCTURE_REPOSITORY} ]; then
-            echo "Cloning Infrastructure repository is skipped since its identical to Scenario repository."
-        else
-            echo Cloning ${props.INFRASTRUCTURE_REPOSITORY} into ${props.WORKSPACE}/${testPlanId}/${props.INFRA_LOCATION}
-            git clone ${props.INFRASTRUCTURE_REPOSITORY}
-        fi
+        echo cloning infrastructure repository: ${props.INFRASTRUCTURE_REPOSITORY} into ${props.WORKSPACE}/${testPlanId}/${props.INFRA_LOCATION}
+        git clone ${props.INFRASTRUCTURE_REPOSITORY} ${props.INFRA_LOCATION}
+
+        echo cloning deployment repository: ${props.DEPLOYMENT_REPOSITORY} into ${props.WORKSPACE}/${testPlanId}/${props.DEPLOYMENT_LOCATION}
+        git clone ${props.DEPLOYMENT_REPOSITORY} ${props.DEPLOYMENT_LOCATION}      
+        
+        echo cloning scenarios repository: ${props.SCENARIOS_REPOSITORY} into ${props.WORKSPACE}/${testPlanId}/${props.SCENARIOS_LOCATION}
+        git clone ${props.SCENARIOS_REPOSITORY} ${props.SCENARIOS_LOCATION}     
+
         echo Workspace directory content:
         ls ${props.WORKSPACE}/${testPlanId}/
     """

--- a/src/org/wso2/tg/jenkins/util/WorkSpaceUtils.groovy
+++ b/src/org/wso2/tg/jenkins/util/WorkSpaceUtils.groovy
@@ -34,9 +34,9 @@ def createJobConfigYamlFile(def filePath) {
     log.info("Creating Job-config.yaml at : {$filePath}")
     sh """
     echo 'keyFileLocation: "${props.SSH_KEY_FILE_PATH}"' > ${filePath}
-    echo 'infrastructureRepository: "${props.INFRA_LOCATION}/"' >> ${filePath}
-    echo 'deploymentRepository: "${props.DEPLOYMENT_LOCATION}/"' >> ${filePath}
-    echo 'scenarioTestsRepository: "${props.SCENARIOS_LOCATION}"' >> ${filePath}
+    echo 'infrastructureRepository: "workspace/${props.INFRA_LOCATION}/"' >> ${filePath}
+    echo 'deploymentRepository: "workspace/${props.DEPLOYMENT_LOCATION}/"' >> ${filePath}
+    echo 'scenarioTestsRepository: "workspace/${props.SCENARIOS_LOCATION}"' >> ${filePath}
     echo 'testgridYamlLocation: "${props.TESTGRID_YAML_LOCATION}"' >> ${filePath}
     echo 'properties:' >> ${filePath}
     echo '  PRODUCT_GIT_URL: "${props.PRODUCT_GIT_URL}"' >> ${filePath}


### PR DESCRIPTION
## Purpose
Remove getting redundant inputs of repository locations.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes