### PR TITLE
Add Gitops automatic testgrid job creation pipeline

### DIFF
--- a/vars/JobCreatorPipeline.groovy
+++ b/vars/JobCreatorPipeline.groovy
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import jenkins.model.Jenkins
+import org.jenkinsci.plugins.envinject.EnvInjectJobPropertyInfo
+import org.jenkinsci.plugins.envinject.EnvInjectJobProperty
+import org.wso2.tg.jenkins.Logger
+import org.wso2.tg.jenkins.PipelineContext
+import org.wso2.tg.jenkins.Properties
+import org.wso2.tg.jenkins.alert.Email
+import org.wso2.tg.jenkins.alert.Slack
+import org.wso2.tg.jenkins.executors.TestExecutor
+import org.wso2.tg.jenkins.executors.TestGridExecutor
+import org.wso2.tg.jenkins.util.*
+
+def JENKINS_SHARED_LIB_NAME = 'intg_test_template@dev'
+def JOB_CONFIG_REPO_RAW_URL = 'https://raw.githubusercontent.com/wso2-incubator/testgrid-job-configs/master/'
+
+call() //TODO: remove
+
+def call() {
+  // Setting the current pipeline context, this should be done initially
+  PipelineContext.instance.setContext(this)
+  // Initializing environment properties
+  def props = Properties.instance
+  props.instance.initProperties()
+
+  // For scaling we need to create slave nodes before starting the pipeline and schedule it appropriately
+  def alert = new Slack()
+  def email = new Email()
+  def awsHelper = new AWSUtils()
+  def testExecutor = new TestExecutor()
+  def tgExecutor = new TestGridExecutor()
+  def runtime = new RuntimeUtils()
+  def ws = new WorkSpaceUtils()
+  def common = new Common()
+  def log = new Logger()
+  def config = new ConfigUtils()
+
+  pipeline {
+    agent {
+      node {
+        label ""
+        customWorkspace "${props.WORKSPACE}"
+      }
+    }
+
+    stages {
+      stage('Create Testgrid Job') {
+        steps {
+          deleteDir()
+          git url: 'https://github.com/kasunbg/testgrid-job-configs', branch: 'job-creator-test'
+
+          script {
+            def changeLogSets = currentBuild.changeSet
+            for (int i = 0; i < changeLogSets.size(); i++) {
+              def entries = changeLogSets[i].items
+              for (int j = 0; j < entries.length; j++) {
+                def entry = entries[j]
+                echo "${entry.commitId} by ${entry.author} on ${new Date(entry.timestamp)}: ${entry.msg}"
+                def files = new ArrayList(entry.affectedFiles)
+                for (int k = 0; k < files.size(); k++) {
+                  def file = files[k]
+                  echo "  ${file.editType.name} ${file.path}"
+                  handleChange(${file.editType.name}, ${file.path})
+                }
+              }
+            }
+
+          }
+
+        }
+      }
+    }
+  }
+}
+
+def handleChange(String action, String filePath) {
+  switch (action) {
+    case "add":
+      addOrModifyJenkinsJob(editType, filePath)
+      break
+    case "modify":
+      addOrModifyJenkinsJob(editType, filePath)
+      break
+    case "delete":
+    default:
+
+      break
+  }
+}
+
+def addOrModifyJenkinsJob(def action, filePath) {
+  echo "Processing file $action: $filePath"
+  def tgYamlContent
+  def jobName
+  try {
+    // Reading the yaml file
+    jobConfigYaml = readYaml file: filePath
+    log.info("Job config yaml content : ${jobConfigYaml}")
+
+//    def addToJenkins = tgYamlContent.jobConfigs.onboardJob
+//    log.info("The onboarding flag is " + addToJenkins)
+//    if (addToJenkins == false) {
+//      log.warn("Skipping on-boarding the testgrid yaml for " + files[i])
+//      continue
+//    }
+
+    jobName = filePath
+//    if (jobName == null || jobName == "") {
+//      jobName = gennerateJobName()
+//    }
+    def emailToList = jobConfigYaml.jobConfig.emailToList
+    if ("add" == action && isJobExists(jobName)) {
+      log.warn("Found an existing job with the name: " + jobName + ". Will update that instead.")
+    }
+    createJenkinsJob(jobName, "", filePath, jobConfigYaml)
+    //TODO: Email to the committer after creating the job
+    //Email email = new Email()
+    //email.send("Auto build creation Notification")
+  } catch (e) {
+    echo "Error while creating the job ${e.getMessage()}"
+    // TODO: notify about the error
+  }
+}
+
+/**
+ * TODO: handle job names with folders.
+ *
+ * @param jobName
+ * @return
+ */
+boolean isJobExists(def jobName) {
+  Jenkins.instance.getAllItems(AbstractItem.class).each {
+    echo "iterating $it.fullName";
+    if (it.fullName == jobName) {
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * This method is responsible for creating the Jenkins job.
+ *
+ * @param jobName jobName
+ * @param timerConfig cron expression to schedule the job
+ * @return
+ */
+def createJenkinsJob(def jobName, def timerConfig, def file, def jobConfigYaml) {
+
+  echo "Creating the job ${jobName}"
+  echo "shared lib name: ${JENKINS_SHARED_LIB_NAME}"  //todo remove
+  def jobDSL="@Library('$JENKINS_SHARED_LIB_NAME') _\n" +
+          "Pipeline()"
+  def instance = Jenkins.instance
+  def job = new org.jenkinsci.plugins.workflow.job.WorkflowJob(instance, jobName)
+  def flowDefinition = new org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition(jobDSL, true)
+  job.definition = flowDefinition
+  job.setConcurrentBuild(false)
+
+  if (timerConfig != null && timerConfig != "") {
+    hudson.triggers.TimerTrigger newCron = new hudson.triggers.TimerTrigger(timerConfig)
+    newCron.start(job, true)
+    job.addTrigger(newCron)
+  }
+  def testgridYamlURL = jobConfigYaml.testgridYamlURL;
+  def rawGitHubFileLocation = getRawGitHubFileLocation(file)
+  addJobProperty(LocalProperties.TESTGRID_YAML_URL_KEY, testgridYamlURL, job)
+  addJobProperty(LocalProperties.JOB_CONFIG_YAML_URL_KEY, rawGitHubFileLocation, job)
+  job.save()
+  Jenkins.instance.reload()
+
+}
+
+private void addJobProperty(String key, value, org.jenkinsci.plugins.workflow.job.WorkflowJob job) {
+  def prop = new EnvInjectJobPropertyInfo("", key + "=${value}", "",
+          "", "", false)
+  prop = new EnvInjectJobProperty(prop)
+  prop.setOn(true)
+  prop.setKeepBuildVariables(true)
+  prop.setKeepJenkinsSystemVariables(true)
+  job.addProperty(prop2)
+}
+
+String getRawGitHubFileLocation(def fileLocation) {
+  return JOB_CONFIG_REPO_RAW_URL + fileLocation
+}

--- a/vars/JobCreatorPipeline.groovy
+++ b/vars/JobCreatorPipeline.groovy
@@ -30,8 +30,8 @@ import org.wso2.tg.jenkins.alert.Slack
 @Singleton
 class JobCreatorProperties {
   final static JENKINS_SHARED_LIB_NAME = 'intg_test_template@dev'
-  final static GIT_REPO = 'kasunbg/testgrid-job-configs'
-  final static GIT_BRANCH = 'job-creator-test'
+  final static GIT_REPO = 'wso2-incubator/testgrid-job-configs'
+  final static GIT_BRANCH = 'master'
   final static JOB_CONFIG_REPO_RAW_URL = "https://raw.githubusercontent.com/${GIT_REPO}/${GIT_BRANCH}/"
 
   final static String TESTGRID_YAML_URL_KEY = "TESTGRID_YAML_URL"
@@ -67,8 +67,6 @@ def call() {
         steps {
           deleteDir()
           git url: "https://github.com/${JobCreatorProperties.GIT_REPO}", branch: "${JobCreatorProperties.GIT_BRANCH}"
-
-          echo "Git URL: ${env}"
           script {
             try {
               def changedFiles = getChangedFiles()
@@ -77,7 +75,6 @@ def call() {
               handleException(e.getMessage(), e)
             }
           }
-
         }
       }
     }

--- a/vars/jenkins.gdsl
+++ b/vars/jenkins.gdsl
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//The global script scope
+def ctx = context(scope: scriptScope())
+
+//What things can be on the script scope
+contributor(ctx) {
+    method(name: 'pipeline', type: 'Object', params: [body: Closure])
+    property(name: 'params', type: 'org.jenkinsci.plugins.workflow.cps.ParamsVariable')
+    property(name: 'env', type: 'org.jenkinsci.plugins.workflow.cps.EnvActionImpl.Binder')
+    property(name: 'currentBuild', type: 'org.jenkinsci.plugins.workflow.cps.RunWrapperBinder')
+    property(name: 'scm', type: 'org.jenkinsci.plugins.workflow.multibranch.SCMVar')
+}
+
+// Define default env vars
+def envVars = context(ctype: 'org.jenkinsci.plugins.workflow.cps.EnvActionImpl.Binder')
+
+contributor(envVars) {
+    property(name: 'BRANCH_NAME', type: 'String', doc: 'For a multibranch project, this will be set to the name of the branch being built, for example in case you wish to deploy to production from master but not from feature branches; if corresponding to some kind of change request, the name is generally arbitrary (refer to CHANGE_ID and CHANGE_TARGET).')
+    property(name: 'CHANGE_ID', type: 'String', doc: 'For a multibranch project corresponding to some kind of change request, this will be set to the change ID, such as a pull request number, if supported; else unset.')
+    property(name: 'CHANGE_URL', type: 'Strig', doc: 'For a multibranch project corresponding to some kind of change request, this will be set to the change URL, if supported; else unset.')
+    property(name: 'CHANGE_TITLE', type: 'String', doc: 'For a multibranch project corresponding to some kind of change request, this will be set to the title of the change, if supported; else unset.')
+    property(name: 'CHANGE_AUTHOR', type: 'String', doc: 'For a multibranch project corresponding to some kind of change request, this will be set to the username of the author of the proposed change, if supported; else unset.')
+    property(name: 'CHANGE_AUTHOR_DISPLAY_NAME', type: 'String', doc: 'For a multibranch project corresponding to some kind of change request, this will be set to the human name of the author, if supported; else unset.')
+    property(name: 'CHANGE_AUTHOR_EMAIL', type: 'String', doc: 'For a multibranch project corresponding to some kind of change request, this will be set to the email address of the author, if supported; else unset.')
+    property(name: 'CHANGE_TARGET', type: 'String', doc: 'rFo a multibranch project corresponding to some kind of change request, this will be set to the target or base branch to which the change could be merged, if supported; else unset.')
+    property(name: 'BUILD_NUMBER', type: 'String', doc: 'The current build number, such as "153"')
+    property(name: 'BUILD_ID', type: 'String', doc: 'The current build ID, identical to BUILD_NUMBER for builds created in 1.597+, but a YYYY-MM-DD_hh-mm-ss timestamp for older builds')
+    property(name: 'BUILD_DISPLAY_NAME', type: 'String', doc: 'The display name of the current build, which is something like "#153" by default.')
+    property(name: 'JOB_NAME', type: 'String', doc: 'Name of the project of this build, such as "foo" or "foo/bar".')
+    property(name: 'JOB_BASE_NAME', type: 'String', doc: 'Short Name of the project of this build stripping off folder paths, such as "foo" for "bar/foo".')
+    property(name: 'BUILD_TAG', type: 'String', doc: 'String of "jenkins-${JOB_NAME}-${BUILD_NUMBER}". All forward slashes (/) in the JOB_NAME are replaced with dashes (-). Convenient to put into a resource file, a jar file, etc for easier identification.')
+    property(name: 'EXECUTOR_NUMBER', type: 'String', doc: 'The unique number that identifies the current executor (among executors of the same machine) that’s carrying out this build. This is the number you see in the "build executor status", except that the number starts from 0, not 1.')
+    property(name: 'NODE_NAME', type: 'String', doc: 'Name of the agent if the build is on an agent, or "master" if run on master')
+    property(name: 'NODE_LABELS', type: 'String', doc: 'Whitespace-separated list of labels that the node is assigned.')
+    property(name: 'WORKSPACE', type: 'String', doc: 'The absolute path of the directory assigned to the build as a workspace.')
+    property(name: 'JENKINS_HOME', type: 'String', doc: 'The absolute path of the directory assigned on the master node for Jenkins to store data.')
+    property(name: 'JENKINS_URL', type: 'String', doc: 'Full URL of Jenkins, like http://server:port/jenkins/ (note: only available if Jenkins URL set in system configuration)')
+    property(name: 'BUILD_URL', type: 'String', doc: 'Full URL of this build, like http://server:port/jenkins/job/foo/15/ (Jenkins URL must be set)')
+    property(name: 'JOB_URL', type: 'String', doc: 'Full URL of this job, like http://server:port/jenkins/job/foo/ (Jenkins URL must be set)')
+}
+
+// Definew all the properties in current builds
+def currentBuild = context(ctype: 'org.jenkinsci.plugins.workflow.cps.RunWrapperBinder')
+
+contributor(currentBuild) {
+    property(name: 'number', type: 'Integer', doc: 'build number')
+    property(name: 'result', type: 'String', doc: 'typically SUCCESS, UNSTABLE, or FAILURE (may be null for an ongoing build)')
+    property(name: 'currentResult', type: 'String', doc: 'typically SUCCESS, UNSTABLE, or FAILURE (never null)')
+    method(name: 'resultIsBetterOrEqualTo', type: 'Boolean', params: [buildStatus: 'String'], doc: 'Compares the current build result to the provided result string (SUCCESS, UNSTABLE, or FAILURE) and returns true if the current build result is better than or equal to the provided result.')
+    method(name: 'resultIsWorseOrEqualTo', type: 'Boolean', params: [buildStatus: 'String'], doc: 'Compares the current build result to the provided result string (SUCCESS, UNSTABLE, or FAILURE) and returns true if the current build result is worse than or equal to the provided result.')
+    property(name: 'displayName', type: 'String', doc: 'normally #123 but sometimes set to, e.g., an SCM commit identifier')
+    property(name: 'description', type: 'String', doc: 'additional information about the build')
+    property(name: 'id', type: 'String', doc: 'normally number as a string')
+    property(name: 'timeInMillis', type: 'long', doc: 'time since the epoch when the build was scheduled')
+    property(name: 'startTimeInMillis', type: 'long', doc: 'time since the epoch when the build started running')
+    property(name: 'duration', type: 'long', doc: 'duration of the build in milliseconds')
+    property(name: 'durationString', type: 'String', doc: 'a human-readable representation of the build duration')
+    property(name: 'previousBuild', type: 'org.jenkinsci.plugins.workflow.cps.RunWrapperBinder', doc: 'another similar object, or null')
+    property(name: 'nextBuild', type: 'org.jenkinsci.plugins.workflow.cps.RunWrapperBinder', doc: 'another similar object, or null')
+    property(name: 'absoluteUrl', type: 'String', doc: 'URL of build index page')
+    property(name: 'buildVariables', type: 'Map', doc: 'for a non-Pipeline downstream build, offers access to a map of defined build variables; for a Pipeline downstream build, any variables set globally on env')
+    property(name: 'changeSets', type: 'String', doc: 'a list of changesets coming from distinct SCM checkouts; each has a kind and is a list of commits; each commit has a commitId, timestamp, msg, author, and affectedFiles each of which has an editType and path; the value will not generally be Serializable so you may only access it inside a method marked @NonCPS')
+    property(name: 'rawBuild', type: 'String', doc: 'a hudson.model.Run with further APIs, only for trusted libraries or administrator-approved scripts outside the sandbox; the value will not be Serializable so you may only access it inside a method marked @NonCPS')
+}
+
+def closures = context(scope: closureScope())
+
+contributor(closures) {
+    // What things can be inside a pipeline
+    if (enclosingCall("pipeline")) {
+        method(name: 'echo', type: 'Object', params: [message: 'java.lang.String'], doc: 'Print Message')
+        method(name: 'stages', type: 'Object', params: [body: 'Closure'], doc: 'Stages')
+        method(name: 'agent', type: 'Object', params: [body: 'Closure'], doc: 'Label expression to select agents')
+        method(name: 'parameters', type: 'Object', params: [body: 'Closure'], doc: 'Job parameters')
+        method(name: 'options', type: 'Object', params: [body: 'Closure'])
+        method(name: 'triggers', type: 'Object', params: [body: 'Closure'], doc: 'Build triggers')
+        method(name: 'post', type: 'Object', params: [body: 'Closure'], doc: 'Post build actions')
+        method(name: 'jiraComment', type: 'Object', namedParams: [parameter(name: 'issueKey', type: 'java.lang.String'), parameter(name: 'body', type: 'java.lang.String'),], doc: 'JIRA: Add a comment to issue(s)')
+        method(name: 'jiraIssueSelector', type: 'Object', params: [:], doc: 'JIRA: Issue selector')
+        method(name: 'jiraIssueSelector', type: 'Object', namedParams: [parameter(name: 'issueSelector', type: 'Map'),], doc: 'JIRA: Issue selector')
+        method(name: 'jiraSearch', type: 'Object', params: [jql: 'java.lang.String'], doc: 'JIRA: Search issues')
+
+        //I  don't know the fate of these one
+        method(name: 'build', type: 'Object', params: [job: 'java.lang.String'], doc: 'Build a job')
+        method(name: 'build', type: 'Object', namedParams: [parameter(name: 'job', type: 'java.lang.String'), parameter(name: 'parameters', type: 'Map'), parameter(name: 'propagate', type: 'boolean'), parameter(name: 'quietPeriod', type: 'java.lang.Integer'), parameter(name: 'wait', type: 'boolean'),], doc: 'Build a job')
+        method(name: 'ec2', type: 'Object', namedParams: [parameter(name: 'cloud', type: 'java.lang.String'), parameter(name: 'template', type: 'java.lang.String'),], doc: 'Cloud template provisioning')
+        method(name: 'error', type: 'Object', params: [message: 'java.lang.String'], doc: 'Error signal')
+        method(name: 'input', type: 'Object', params: [message: 'java.lang.String'], doc: 'Wait for interactive input')
+        method(name: 'input', type: 'Object', namedParams: [parameter(name: 'message', type: 'java.lang.String'), parameter(name: 'id', type: 'java.lang.String'), parameter(name: 'ok', type: 'java.lang.String'), parameter(name: 'parameters', type: 'Map'), parameter(name: 'submitter', type: 'java.lang.String'), parameter(name: 'submitterParameter', type: 'java.lang.String'),], doc: 'Wait for interactive input')
+        method(name: 'isUnix', type: 'Object', params: [:], doc: 'Checks if running on a Unix-like node')
+        method(name: 'library', type: 'Object', params: [identifier: 'java.lang.String'], doc: 'Load a shared library on the fly')
+        method(name: 'library', type: 'Object', namedParams: [parameter(name: 'identifier', type: 'java.lang.String'), parameter(name: 'changelog', type: 'java.lang.Boolean'), parameter(name: 'retriever', type: 'Map'),], doc: 'Load a shared library on the fly')
+        method(name: 'libraryResource', type: 'Object', params: [resource: 'java.lang.String'], doc: 'Load a resource file from a shared library')
+        method(name: 'mail', type: 'Object', namedParams: [parameter(name: 'subject', type: 'java.lang.String'), parameter(name: 'body', type: 'java.lang.String'), parameter(name: 'bcc', type: 'java.lang.String'), parameter(name: 'cc', type: 'java.lang.String'), parameter(name: 'charset', type: 'java.lang.String'), parameter(name: 'from', type: 'java.lang.String'), parameter(name: 'mimeType', type: 'java.lang.String'), parameter(name: 'replyTo', type: 'java.lang.String'), parameter(name: 'to', type: 'java.lang.String'),], doc: 'Mail')
+        method(name: 'milestone', type: 'Object', params: [ordinal: 'java.lang.Integer'], doc: 'The milestone step forces all builds to go through in order')
+        method(name: 'milestone', type: 'Object', namedParams: [parameter(name: 'ordinal', type: 'java.lang.Integer'), parameter(name: 'label', type: 'java.lang.String'),], doc: 'The milestone step forces all builds to go through in order')
+        method(name: 'node', type: 'Object', params: [body: 'Closure'], doc: 'Allocate node')
+        method(name: 'node', type: 'Object', params: [label: 'String', body: 'Closure'], doc: 'Allocate node')
+        method(name: 'properties', type: 'Object', params: [properties: 'Map'], doc: 'Set job properties')
+        method(name: 'readTrusted', type: 'Object', params: [path: 'java.lang.String'], doc: 'Read trusted file from SCM')
+        method(name: 'resolveScm', type: 'Object', namedParams: [parameter(name: 'source', type: 'Map'), parameter(name: 'targets', type: 'Map'), parameter(name: 'ignoreErrors', type: 'boolean'),], doc: 'Resolves an SCM from an SCM Source and a list of candidate target branch names')
+        method(name: 'retry', type: 'Object', params: [count: int, body: 'Closure'], doc: 'Retry the body up to N times')
+        method(name: 'script', type: 'Object', params: [body: 'Closure'], doc: 'Run arbitrary Pipeline script')
+        method(name: 'sleep', type: 'Object', params: [time: 'int'], doc: 'Sleep')
+        method(name: 'sleep', type: 'Object', namedParams: [parameter(name: 'time', type: 'int'), parameter(name: 'unit', type: 'java.util.concurrent.TimeUnit'),], doc: 'Sleep')
+        method(name: 'timeout', type: 'Object', params: [time: int, body: 'Closure'], doc: 'Enforce time limit')
+        method(name: 'timeout', type: 'Object', params: [body: Closure], namedParams: [parameter(name: 'time', type: 'int'), parameter(name: 'unit', type: 'java.util.concurrent.TimeUnit'),], doc: 'Enforce time limit')
+        method(name: 'tool', type: 'Object', params: [name: 'java.lang.String'], doc: 'Use a tool from a predefined Tool Installation')
+        method(name: 'tool', type: 'Object', namedParams: [parameter(name: 'name', type: 'java.lang.String'), parameter(name: 'type', type: 'java.lang.String'),], doc: 'Use a tool from a predefined Tool Installation')
+        method(name: 'waitUntil', type: 'Object', params: [body: 'Closure'], doc: 'Wait for condition')
+        method(name: 'withCredentials', type: 'Object', params: [bindings: Map, body: 'Closure'], doc: 'Bind credentials to variables')
+        method(name: 'withEnv', type: 'Object', params: [overrides: Map, body: 'Closure'], doc: 'Set environment variables')
+        method(name: 'ws', type: 'Object', params: [dir: 'String', body: 'Closure'], doc: 'Allocate workspace')
+        method(name: 'catchError', type: 'Object', params: [body: 'Closure'], doc: 'Advanced/Deprecated Catch error and set build result')
+        method(name: 'dockerFingerprintRun', type: 'Object', params: [containerId: 'java.lang.String'], doc: 'Advanced/Deprecated Record trace of a Docker image run in a container')
+        method(name: 'dockerFingerprintRun', type: 'Object', namedParams: [parameter(name: 'containerId', type: 'java.lang.String'), parameter(name: 'toolName', type: 'java.lang.String'),], doc: 'Record trace of a Docker image run in a container')
+        method(name: 'envVarsForTool', type: 'Object', namedParams: [parameter(name: 'toolId', type: 'java.lang.String'), parameter(name: 'toolVersion', type: 'java.lang.String'),], doc: 'Fetches the environment variables for a given tool in a list of \'FOO=bar\' strings suitable for the withEnv step.')
+        method(name: 'getContext', type: 'Object', params: [type: 'Map'], doc: 'Advanced/Deprecated Get contextual object from internal APIs')
+        method(name: 'withContext', type: 'Object', params: [context: 'Object', body: 'Closure'], doc: 'Advanced/Deprecated Use contextual object from internal APIs within a block')
+
+    }
+
+    //The only thing inside agent can be label
+    if (enclosingCall("agent")) {
+        property(name: 'any')
+        property(name: 'none')
+        method(name: 'label', type: 'String', params: [expr: 'String'])
+        method(name: 'docker', type: 'String', params: [docker_image: 'String'])
+        method(name: 'dockerfile', type: 'boolean', params: [use_dockerfile: 'boolean'])
+    }
+
+    if (enclosingCall("triggers")) {
+        method(name: 'cron', type: 'String', params: [expr: 'String'], doc: 'Cron expression can be one of @daily, @hourly, etc')
+        method(name: 'upstream', type: 'Object', params: [name: 'String', build_status: 'Object'])
+        method(name: 'pollSCM', type: 'String', params: [expr: 'String'])
+        method(name: 'bitbucketPush')
+    }
+
+    // Parameters can only contain
+    if (enclosingCall("parameters")) {
+        method(name: 'string', type: 'Object', namedParams: [parameter(name: 'name', type: 'java.lang.String'), parameter(name: 'defaultValue', type: 'java.lang.String'), parameter(name: 'description', type: 'java.lang.String')])
+        method(name: 'booleanParam', type: 'Object', namedParams: [parameter(name: 'name', type: 'java.lang.String'), parameter(name: 'defaultValue', type: 'java.lang.Boolean'), parameter(name: 'description', type: 'java.lang.String')])
+        method(name: 'choice', type: 'Object', namedParams: [parameter(name: 'choice', type: 'java.lang.String'), parameter(name: 'defaultValue', type: 'java.lang.Boolean'), parameter(name: 'description', type: 'java.lang.String')])
+    }
+
+    // Find the options!
+    if (enclosingCall("options")) {
+        method(name: 'buildDiscarder')
+        method(name: 'timestamps')
+        method(name: 'timeout', type: 'Object', namedParams: [parameter(name: 'time', type: 'java.lang.Integer'), parameter(name: 'unit', type: 'java.lang.String')])
+    }
+
+    // Inside stages can be, stage or stage('Name')
+    if (enclosingCall("stages")) {
+        method(name: 'stage', type: 'Object', params: [name: 'String', body: 'Closure'], doc: 'Stage')
+        method(name: 'stage', type: 'Object', params: [body: Closure], namedParams: [parameter(name: 'name', type: 'java.lang.String'), parameter(name: 'concurrency', type: 'java.lang.Integer'),], doc: 'Stage')
+    }
+
+    // Inside steps only steps
+    if (enclosingCall("stage")) {
+        method(name: 'agent', type: 'Object', params: [body: 'Closure'], doc: 'Label expression to select agents')
+        method(name: 'steps', type: 'Object', params: [body: 'Closure'], doc: 'Steps to execute on stage')
+        method(name: 'post', type: 'Object', params: [body: 'Closure'], doc: 'Post actions can be executed on a per-stage basis as well')
+    }
+
+    // Only inside steps
+    if (enclosingCall("steps") || enclosingCall("always") || enclosingCall("success") ||
+            enclosingCall("failure") || enclosingCall("unstable") || enclosingCall("changed")) {
+        method(name: 'timestamp', type: 'Object', params: [body: 'Closure'], doc: 'Timestamps')
+        method(name: 'bat', type: 'Object', params: [script: 'java.lang.String'], doc: 'Windows Batch Script')
+        method(name: 'bat', type: 'Object', namedParams: [parameter(name: 'script', type: 'java.lang.String'), parameter(name: 'encoding', type: 'java.lang.String'), parameter(name: 'returnStatus', type: 'boolean'), parameter(name: 'returnStdout', type: 'boolean'),], doc: 'Windows Batch Script')
+        method(name: 'checkout', type: 'Object', params: [scm: 'Map'], doc: 'General SCM')
+        method(name: 'checkout', type: 'Object', namedParams: [parameter(name: 'scm', type: 'Map'), parameter(name: 'changelog', type: 'boolean'), parameter(name: 'poll', type: 'boolean'),], doc: 'General SCM')
+        method(name: 'deleteDir', type: 'Object', params: [:], doc: 'Recursively delete the current directory from the workspace')
+        method(name: 'dir', type: 'Object', params: [path: 'String', body: 'Closure'], doc: 'Change current directory')
+        method(name: 'fileExists', type: 'Object', params: [file: 'java.lang.String'], doc: 'Verify if file exists in workspace')
+        method(name: 'git', type: 'Object', params: [url: 'java.lang.String'], doc: 'Git')
+        method(name: 'git', type: 'Object', namedParams: [parameter(name: 'url', type: 'java.lang.String'), parameter(name: 'branch', type: 'java.lang.String'), parameter(name: 'changelog', type: 'boolean'), parameter(name: 'credentialsId', type: 'java.lang.String'), parameter(name: 'poll', type: 'boolean'),], doc: 'Git')
+        method(name: 'junit', type: 'Object', params: [testResults: 'java.lang.String'], doc: 'Archive JUnit-formatted test results')
+        method(name: 'junit', type: 'Object', namedParams: [parameter(name: 'testResults', type: 'java.lang.String'), parameter(name: 'allowEmptyResults', type: 'boolean'), parameter(name: 'healthScaleFactor', type: 'double'), parameter(name: 'keepLongStdio', type: 'boolean'), parameter(name: 'testDataPublishers', type: 'Map'),], doc: 'Archive JUnit-formatted test results')
+        method(name: 'load', type: 'Object', params: [path: 'java.lang.String'], doc: 'Evaluate a Groovy source file into the Pipeline script')
+        method(name: 'powershell', type: 'Object', params: [script: 'java.lang.String'], doc: 'PowerShell Script')
+        method(name: 'powershell', type: 'Object', namedParams: [parameter(name: 'script', type: 'java.lang.String'), parameter(name: 'encoding', type: 'java.lang.String'), parameter(name: 'returnStatus', type: 'boolean'), parameter(name: 'returnStdout', type: 'boolean'),], doc: 'PowerShell Script')
+        method(name: 'publishHTML', type: 'Object', params: [target: 'Map'], doc: 'Publish HTML reports')
+        method(name: 'pwd', type: 'Object', params: [:], doc: 'Determine current directory')
+        method(name: 'pwd', type: 'Object', namedParams: [parameter(name: 'tmp', type: 'boolean'),], doc: 'Determine current directory')
+        method(name: 'readFile', type: 'Object', params: [file: 'java.lang.String'], doc: 'Read file from workspace')
+        method(name: 'readFile', type: 'Object', namedParams: [parameter(name: 'file', type: 'java.lang.String'), parameter(name: 'encoding', type: 'java.lang.String'),], doc: 'Read file from workspace')
+        method(name: 'sh', type: 'Object', params: [script: 'java.lang.String'], doc: 'Shell Script')
+        method(name: 'sh', type: 'Object', namedParams: [parameter(name: 'script', type: 'java.lang.String'), parameter(name: 'encoding', type: 'java.lang.String'), parameter(name: 'returnStatus', type: 'boolean'), parameter(name: 'returnStdout', type: 'boolean'),], doc: 'Shell Script')
+        method(name: 'stash', type: 'Object', params: [name: 'java.lang.String'], doc: 'Stash some files to be used later in the build')
+        method(name: 'stash', type: 'Object', namedParams: [parameter(name: 'name', type: 'java.lang.String'), parameter(name: 'allowEmpty', type: 'boolean'), parameter(name: 'excludes', type: 'java.lang.String'), parameter(name: 'includes', type: 'java.lang.String'), parameter(name: 'useDefaultExcludes', type: 'boolean'),], doc: 'Stash some files to be used later in the build')
+        method(name: 'tm', type: 'Object', params: [stringWithMacro: 'java.lang.String'], doc: 'Expand a string containing macros')
+        method(name: 'unstash', type: 'Object', params: [name: 'java.lang.String'], doc: 'Restore files previously stashed')
+        method(name: 'validateDeclarativePipeline', type: 'Object', params: [path: 'java.lang.String'], doc: 'Validate a file containing a Declarative Pipeline')
+        method(name: 'wrap', type: 'Object', params: [delegate: Map, body: 'Closure'], doc: 'General Build Wrapper')
+        method(name: 'writeFile', type: 'Object', namedParams: [parameter(name: 'file', type: 'java.lang.String'), parameter(name: 'text', type: 'java.lang.String'), parameter(name: 'encoding', type: 'java.lang.String'),], doc: 'Write file to workspace')
+        method(name: 'archive', type: 'Object', params: [includes: 'java.lang.String'], doc: 'Advanced/Deprecated Archive artifacts')
+        method(name: 'archive', type: 'Object', namedParams: [parameter(name: 'includes', type: 'java.lang.String'), parameter(name: 'excludes', type: 'java.lang.String'),], doc: 'Archive artifacts')
+        method(name: 'dockerFingerprintFrom', type: 'Object', namedParams: [parameter(name: 'dockerfile', type: 'java.lang.String'), parameter(name: 'image', type: 'java.lang.String'), parameter(name: 'buildArgs', type: 'Map'), parameter(name: 'toolName', type: 'java.lang.String'),], doc: 'Record trace of a Docker image used in FROM')
+        method(name: 'unarchive', type: 'Object', params: [:], doc: 'Advanced/Deprecated Copy archived artifacts into the workspace')
+        method(name: 'unarchive', type: 'Object', namedParams: [parameter(name: 'mapping', type: 'Map'),], doc: 'Copy archived artifacts into the workspace')
+        method(name: 'withDockerContainer', type: 'Object', params: [image: 'String', body: 'Closure'], doc: 'Advanced/Deprecated Run build steps inside a Docker container')
+        method(name: 'withDockerContainer', type: 'Object', params: [body: Closure], namedParams: [parameter(name: 'image', type: 'java.lang.String'), parameter(name: 'args', type: 'java.lang.String'), parameter(name: 'toolName', type: 'java.lang.String'),], doc: 'Run build steps inside a Docker container')
+        method(name: 'withDockerRegistry', type: 'Object', params: [registry: Map, body: 'Closure'], doc: 'Advanced/Deprecated Sets up Docker registry endpoint')
+        method(name: 'withDockerServer', type: 'Object', params: [server: Map, body: 'Closure'], doc: 'Advanced/Deprecated Sets up Docker server endpoint')
+        method(name: 'parallel', type: 'Object', params: [body: 'Map'], doc: 'Run taask in parallel')
+    }
+
+    // Post actions!
+    if (enclosingCall("post")) {
+        method(name: 'always', type: 'Object', params: [body: 'Closure'])
+        method(name: 'success', type: 'Object', params: [body: 'Closure'])
+        method(name: 'failure', type: 'Object', params: [body: 'Closure'])
+        method(name: 'unstable', type: 'Object', params: [body: 'Closure'])
+        method(name: 'changed', type: 'Object', params: [body: 'Closure'])
+    }
+}


### PR DESCRIPTION
## Purpose

We need to create testgrid jobs with git as the centralized place of control. This pipeline is added to automate the job creation.

## Goals
Achieve full-automated GitOps

## Approach
A testgrid job will be created in prod whenever a new yaml file is placed in this repo: https://github.com/wso2-incubator/testgrid-job-configs

That file must have the **testgridYamlURL** element that points to a valid testgrid.yaml file:

```
$> cat wum-sce-test-wso2am-2.1.0-full-testgrid.yaml
testgridYamlURL: https://raw.githubusercontent.com/kasunbg/testgrid-job-configs/master/wum-sce-test-wso2ei-6.4.0-full-testgrid.yaml

```

The testgrid.yaml files may reside on the product repos.

