### PR TITLE
Provide blueocean link as an input to RunTestPlan command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,24 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.22</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>2.39</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>2.1</version>
+        </dependency>
+
         <!--LesFurets Jenkins Pipeline Unit testing framework: https://github.com/lesfurets/JenkinsPipelineUnit-->
         <dependency>
             <groupId>com.lesfurets</groupId>

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -42,9 +42,8 @@ def runPlan(tPlan, testPlanId) {
 
     def execName = commonUtil.extractInfraCombination("${testPlanId}")
     def paralleId = getParalleId(execName)
-    def buildURL = "${env.BUILD_URL}"
-    def url = generateBluoceanLink("${buildURL}","${paralleId}")
-    echo "URL : " + "${url}"
+    def url = generateBluoceanLink("${paralleId}")
+    echo "Blueocean link URL : " + "${url}"
 
     scenarioConfigs = readRepositoryUrlsfromYaml("${props.WORKSPACE}/${tPlan}")
     log.info("Preparing workspace for testplan : " + testPlanId)
@@ -199,6 +198,10 @@ def getParalleId(name){
             }
         }
     }
+    /*
+    Its required to make these values null to inform Jenkins that these objects should not be serialized
+    during execution. @NonCPS annotation does not seem to work in this instance.
+     */
     build = null
     actions = null
     parallelname = null
@@ -276,16 +279,10 @@ static def getRepositoryBranch(def branch) {
  * Builds the bluocean console link for a given test plan
  *
  * @param buildURL Jenkins classic build URL
- * @param parallelId Parallel id of the test plan
  * @return Blueocean link
  */
-def generateBluoceanLink(def buildURL , def parallelId){
-    def split = buildURL.split('/')
-    def url = null
-    if (split.length > 0 ){
-        url = split[0] + "//" + split[2] + "/admin/blue/organizations/jenkins/" + split[5] +
-                "/detail/" + split[5] + "/" + split[6] + "/pipeline/" + "${parallelId}"
-    }
+def generateBluoceanLink(def parallelId){
+    def url = "${env.JENKINS_URL}" + "blue/organizations/jenkins/" + "${env.JOB_NAME}" +
+                "/detail/" + "${env.JOB_NAME}" + "/" + "${env.BUILD_ID}" + "/pipeline/" + "${parallelId}"
     return url
-
 }

--- a/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestExecutor.groovy
@@ -29,6 +29,8 @@ import org.wso2.tg.jenkins.util.Common
 import org.wso2.tg.jenkins.util.FileUtils
 import org.wso2.tg.jenkins.util.RuntimeUtils
 
+import java.nio.charset.StandardCharsets
+
 def runPlan(tPlan, testPlanId) {
     def commonUtil = new Common()
     def notifier = new Slack()
@@ -276,13 +278,18 @@ static def getRepositoryBranch(def branch) {
 }
 
 /**
- * Builds the bluocean console link for a given test plan
+ * Builds the blueocean console link for a given test plan
  *
  * @param buildURL Jenkins classic build URL
  * @return Blueocean link
  */
-def generateBluoceanLink(def parallelId){
-    def url = "${env.JENKINS_URL}" + "blue/organizations/jenkins/" + "${env.JOB_NAME}" +
-                "/detail/" + "${env.JOB_NAME}" + "/" + "${env.BUILD_ID}" + "/pipeline/" + "${parallelId}"
+def generateBluoceanLink(def parallelId) {
+    def completeJobName = "${env.JOB_NAME}"
+    def scapedURL = URLEncoder.encode(completeJobName, StandardCharsets.UTF_8.name())
+    def split = completeJobName.split("/")
+    def jobName = split[split.length-1]
+
+    def url = "${env.JENKINS_URL}" + "blue/organizations/jenkins/" + "${scapedURL}" +
+                "/detail/" + "${jobName}" + "/" + "${env.BUILD_ID}" + "/pipeline/" + "${parallelId}"
     return url
 }

--- a/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
@@ -47,7 +47,7 @@ def generateTesPlans(def product, def configYaml) {
  * @param testPlanFilePath test plan location
  * @param workspace execution workspace
  */
-def runTesPlans(def product, def testPlanFilePath, def workspace) {
+def runTesPlans(def product, def testPlanFilePath, def workspace, def url) {
     def props = Properties.instance
     def log = new Logger()
     log.info("Running Test-Plan: " + testPlanFilePath + " of product " + product + " in the workspace " + workspace)
@@ -55,7 +55,7 @@ def runTesPlans(def product, def testPlanFilePath, def workspace) {
         cd ${props.TESTGRID_DIST_LOCATION}/${props.TESTGRID_NAME}
         export TESTGRID_HOME="${props.TESTGRID_HOME}"
         ./testgrid run-testplan --product ${product} \
-            --file ${testPlanFilePath} --workspace ${workspace}        
+            --file ${testPlanFilePath} --workspace ${workspace} --url ${url}       
     """
 }
 

--- a/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
+++ b/src/org/wso2/tg/jenkins/executors/TestGridExecutor.groovy
@@ -46,6 +46,7 @@ def generateTesPlans(def product, def configYaml) {
  * @param product the product to be parsed
  * @param testPlanFilePath test plan location
  * @param workspace execution workspace
+ * @param url Jenkins build url for the test plan
  */
 def runTesPlans(def product, def testPlanFilePath, def workspace, def url) {
     def props = Properties.instance

--- a/src/org/wso2/tg/jenkins/util/Common.groovy
+++ b/src/org/wso2/tg/jenkins/util/Common.groovy
@@ -19,6 +19,8 @@
 package org.wso2.tg.jenkins.util
 
 import org.wso2.tg.jenkins.Properties
+import org.wso2.tg.jenkins.Logger
+
 
 def getTimestamp(Date date = new Date()) {
     return date.format('yyyyMMddHHmmss', TimeZone.getTimeZone('GMT')) as String
@@ -60,6 +62,23 @@ def getTestPlanId(file) {
     def tpyaml = readFile(file)
     def m = tpyaml =~ /(id:)([A-z :'0-9\.-]*)(\n)/
     return m[0][2].trim()
+}
+
+/**
+ * Extracts the infra combination from testplan id to be displayed in the
+ * blueocean UI parallel stages
+ *
+ * @param testPlanId testplan id
+ * @return Only the infra combination section from the testplan
+ */
+def extractInfraCombination(def testPlanId){
+
+    def split = testPlanId.split("_")
+    def name=split[2]
+    for (def i = 3; i < split.length - 1; i++) {
+        name += "_" + split[i]
+    }
+    return name
 }
 
 def getRandomNumber(limit) {

--- a/src/org/wso2/tg/jenkins/util/Common.groovy
+++ b/src/org/wso2/tg/jenkins/util/Common.groovy
@@ -19,7 +19,6 @@
 package org.wso2.tg.jenkins.util
 
 import org.wso2.tg.jenkins.Properties
-import org.wso2.tg.jenkins.Logger
 
 
 def getTimestamp(Date date = new Date()) {


### PR DESCRIPTION
## Purpose
To provide quick access to the blue ocean dashboard for each build we generate the link in pipeline and provide it to RunTestPlan command to store in the database.

### **IMPORTANT**
**Merge this after merging the related TestGrid PR to avoid any build breaks**